### PR TITLE
[java] replace mockito-all with current mockito-core

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -37,8 +37,8 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
-            <version>1.10.19</version>
+            <artifactId>mockito-core</artifactId>
+            <version>5.10.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
`org.mockito:mockito-all` was relocated to `org.mockito:mockito-core`.
`mockito-core` is required to support Java 21.