### PR TITLE
[java] Remove obsolete public modifier

### DIFF
--- a/java/src/test/java/AnyTest.java
+++ b/java/src/test/java/AnyTest.java
@@ -2,7 +2,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class AnyTest {
+class AnyTest {
 
     @Test
     void it_fails() {


### PR DESCRIPTION
The `public` modifier for test methods is not needed anymore.

See https://junit.org/junit5/docs/current/user-guide/#writing-tests-classes-and-methods

> "It is generally recommended to omit the public modifier for test classes, test methods, and lifecycle methods unless there is a technical reason for doing so – for example, when a test class is extended by a test class in another package. Another technical reason for making classes and methods public is to simplify testing on the module path when using the Java Module System."